### PR TITLE
API User Resource CRUD ops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PPA-Enterprises/crispy-fiesta
 
-go 1.14
+go 1.15
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/internal/clients/go.mod
+++ b/internal/clients/go.mod
@@ -1,2 +1,2 @@
 module clients
-go 1.14
+go 1.15

--- a/internal/common/errors/errors.go
+++ b/internal/common/errors/errors.go
@@ -82,3 +82,10 @@ func DoesNotExist() *ResponseError {
 		reason: "Does Not exist",
 	}
 }
+
+func DeleteFailed() *ResponseError {
+	return &ResponseError{
+		Code: http.StatusNotFound,
+		reason: "Deletion Failed",
+	}
+}

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -1,6 +1,6 @@
 module common
 
-go 1.14
+go 1.15
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/internal/jobs/go.mod
+++ b/internal/jobs/go.mod
@@ -1,3 +1,3 @@
 module jobs
-go 1.14
+go 1.15
 

--- a/internal/uid/go.mod
+++ b/internal/uid/go.mod
@@ -1,2 +1,2 @@
 module UID
-go 1.14
+go 1.15

--- a/internal/users/forms.go
+++ b/internal/users/forms.go
@@ -12,7 +12,6 @@ type loginUserCommand struct {
 }
 
 type userUpdateCommand struct {
-	ID			string `json:"_id" binding:"required"`
 	Name		string `json:"name, omitempty"`
 	Email		string `json:"email, omitempty" binding:"required"`
 }

--- a/internal/users/forms.go
+++ b/internal/users/forms.go
@@ -13,6 +13,6 @@ type loginUserCommand struct {
 
 type userUpdateCommand struct {
 	ID			string `json:"_id" binding:"required"`
-	Name		string `json:"name" binding:"required"`
-	Email		string `json:"email" binding:"required"`
+	Name		string `json:"name, omitempty"`
+	Email		string `json:"email, omitempty" binding:"required"`
 }

--- a/internal/users/forms.go
+++ b/internal/users/forms.go
@@ -10,3 +10,9 @@ type loginUserCommand struct {
 	Email		string `json:"email" binding:"required,email"`
 	Password	string `json:"password" binding:"required"`
 }
+
+type userUpdateCommand struct {
+	ID			string `json:"_id" binding:"required"`
+	Name		string `json:"name" binding:"required"`
+	Email		string `json:"email" binding:"required"`
+}

--- a/internal/users/go.mod
+++ b/internal/users/go.mod
@@ -1,6 +1,6 @@
 module users
 
-go 1.14
+go 1.15
 
 require (
 	github.com/gin-gonic/gin v1.6.3

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -58,3 +58,18 @@ func login(c *gin.Context) {
 		gin.H{"success": true, "payload": jwt, "message": "User Authenticated"});
 
 }
+
+func getUsers(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c, 5*time.Second)
+	defer cancel()
+
+	users, err := fetchUsers(ctx)
+	if err != nil {
+		c.JSON(err.Code,
+			gin.H{"success": false, "message": err.Error()})
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK,
+		gin.H{"success": true, "payload": users})
+}

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -116,3 +116,25 @@ func update(c *gin.Context) {
 	c.JSON(http.StatusCreated,
 	gin.H{"success": true, "payload": updatedDoc, "message": "User Updated"});
 }
+
+func delete(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c, 5*time.Second)
+	defer cancel()
+
+	id := c.Param("id")
+	if len(id) <= 0 {
+		c.JSON(http.StatusBadRequest,
+		gin.H{"success": false, "message": "Provide an id"})
+		c.Abort()
+		return
+	}
+
+	if err := deleteUser(ctx, id); err != nil {
+		c.JSON(err.Code,
+			gin.H{"success": false, "message": err.Error()})
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK,
+	gin.H{"success": true, "message": "User Removed"});
+}

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -80,7 +80,6 @@ func getUsers(c *gin.Context) {
 			gin.H{"success": true, "payload": empty})
 }
 
-//TODO: Return updated data or id?
 func update(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()
@@ -93,19 +92,27 @@ func update(c *gin.Context) {
 		return
 	}
 
-	updatePatch, err := tryFromUpdateUserCmd(&data); if err != nil {
+	id := c.Param("id")
+	if len(id) <= 0 {
+		c.JSON(http.StatusBadRequest,
+		gin.H{"success": false, "message": "Provide an id"})
+		c.Abort()
+		return
+	}
+
+	updatePatch, err := tryFromUpdateUserCmd(&data, id); if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
 		c.Abort()
 		return
 	}
 
-	patchErr := updatePatch.patch(ctx, false); if err != nil {
+	updatedDoc, patchErr := updatePatch.patch(ctx, false); if patchErr != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": patchErr.Error()})
 		c.Abort()
 		return
 	}
 	c.JSON(http.StatusCreated,
-		gin.H{"success": true, "message": "User Updated"});
+	gin.H{"success": true, "payload": updatedDoc, "message": "User Updated"});
 }

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -72,6 +72,12 @@ func getUsers(c *gin.Context) {
 		return
 	}
 	fmt.Println(users)
-	c.JSON(http.StatusOK,
-		gin.H{"success": true, "payload": users})
+	if len(users) > 0 {
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": users})
+		return
+	}
+		empty := make([]string, 0)
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": empty})
 }

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -108,7 +108,7 @@ func update(c *gin.Context) {
 	}
 
 	updatedDoc, patchErr := updatePatch.patch(ctx, false); if patchErr != nil {
-		c.JSON(err.Code,
+		c.JSON(patchErr.Code,
 			gin.H{"success": false, "message": patchErr.Error()})
 		c.Abort()
 		return

--- a/internal/users/handlers.go
+++ b/internal/users/handlers.go
@@ -1,5 +1,6 @@
 package users
 import (
+	"fmt"
 	"context"
 	"time"
 	"net/http"
@@ -70,6 +71,7 @@ func getUsers(c *gin.Context) {
 		c.Abort()
 		return
 	}
+	fmt.Println(users)
 	c.JSON(http.StatusOK,
 		gin.H{"success": true, "payload": users})
 }

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -91,7 +91,7 @@ func EmailExists(ctx context.Context, email string) bool {
 func fetchUsers(ctx context.Context)([]types.DeliverableUser, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "users")
 
-	cursor, err := coll.Find(ctx, bson.D{{}})
+	cursor, err := coll.Find(ctx, bson.D{{"password",false}})
 	defer cursor.Close(ctx)
 
 	var users []types.DeliverableUser

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -109,7 +109,7 @@ func EmailExists(ctx context.Context, email string) bool {
 func fetchUsers(ctx context.Context)([]types.DeliverableUser, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "users")
 
-	cursor, err := coll.Find(ctx, bson.D{{"password",false}})
+	cursor, err := coll.Find(ctx, bson.D{{}})
 	defer cursor.Close(ctx)
 
 	var users []types.DeliverableUser

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -96,6 +96,7 @@ func fetchUsers(ctx context.Context)([]types.DeliverableUser, *errors.ResponseEr
 
 	var users []types.DeliverableUser
 	if err = cursor.All(ctx, &users); err != nil {
+		//empty := make([]types.DeliverableUser, 0)
 		return nil, errors.DatabaseError(err)
 	}
 	return users, nil

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -114,7 +114,6 @@ func fetchUsers(ctx context.Context)([]types.DeliverableUser, *errors.ResponseEr
 
 	var users []types.DeliverableUser
 	if err = cursor.All(ctx, &users); err != nil {
-		//empty := make([]types.DeliverableUser, 0)
 		return nil, errors.DatabaseError(err)
 	}
 	return users, nil
@@ -137,6 +136,5 @@ func (self *userUpdateModel) patch(ctx context.Context, upsert bool) (*types.Del
 	if err != nil {
 		return nil, errors.DatabaseError(err)
 	}
-
 	return &updatedDocument, nil
 }

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -2,7 +2,6 @@ package users
 
 import (
 	"context"
-
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -87,3 +87,15 @@ func EmailExists(ctx context.Context, email string) bool {
 	return true
 }
 
+func users(ctx context.Context)([]types.DeliverableUser, *errors.ResponseError) {
+	coll := db.Connection().Use(db.DefaultDatabase, "users")
+
+	cursor, err := coll.Find(ctx, bson.D{{}})
+	defer cursor.Close(ctx)
+
+	var users []types.DeliverableUser
+	if err = cursor.All(ctx, &users); err != nil {
+		return nil, errors.DatabaseError(err)
+	}
+	return users, nil
+}

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -24,8 +24,8 @@ type userModel struct {
 
 type userUpdateModel struct {
 	ID primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
-	Name string `json:"name" bson:"name"`
-	Email string `json:"email" bson:"email"`
+	Name string `json:"name" bson:"name,omitempty"`
+	Email string `json:"email" bson:"email,omitempty"`
 }
 
 func tryFromSignupUserCmd(data *signupUserCommand) (*userModel, *errors.ResponseError) {

--- a/internal/users/models.go
+++ b/internal/users/models.go
@@ -10,6 +10,7 @@ import (
 	jwtUtils "internal/common/token"
 	"internal/db"
 	"internal/uid"
+	"internal/users/types"
 )
 
 type userModel struct {
@@ -87,7 +88,7 @@ func EmailExists(ctx context.Context, email string) bool {
 	return true
 }
 
-func users(ctx context.Context)([]types.DeliverableUser, *errors.ResponseError) {
+func fetchUsers(ctx context.Context)([]types.DeliverableUser, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "users")
 
 	cursor, err := coll.Find(ctx, bson.D{{}})

--- a/internal/users/routers.go
+++ b/internal/users/routers.go
@@ -7,4 +7,5 @@ import (
 func UserRoutesRegister(router *gin.RouterGroup) {
 	router.POST("/", signup)
 	router.POST("/login", login)
+	router.GET("/", getUsers)
 }

--- a/internal/users/routers.go
+++ b/internal/users/routers.go
@@ -8,5 +8,5 @@ func UserRoutesRegister(router *gin.RouterGroup) {
 	router.POST("/", signup)
 	router.POST("/login", login)
 	router.GET("/", getUsers)
-	router.PATCH("/", update)
+	router.PATCH("/:id", update)
 }

--- a/internal/users/routers.go
+++ b/internal/users/routers.go
@@ -9,4 +9,5 @@ func UserRoutesRegister(router *gin.RouterGroup) {
 	router.POST("/login", login)
 	router.GET("/", getUsers)
 	router.PATCH("/:id", update)
+	router.DELETE("/:id", delete)
 }

--- a/internal/users/routers.go
+++ b/internal/users/routers.go
@@ -8,4 +8,5 @@ func UserRoutesRegister(router *gin.RouterGroup) {
 	router.POST("/", signup)
 	router.POST("/login", login)
 	router.GET("/", getUsers)
+	router.PATCH("/", update)
 }

--- a/internal/users/types/types.go
+++ b/internal/users/types/types.go
@@ -6,5 +6,5 @@ type DeliverableUser struct {
 	ID primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	Name string `json:"name" bson:"name"`
 	Email string `json:"email" bson:"email"`
-	IsVerified bool `json:"is_verified" bson:"is_verified"`
+	//IsVerified bool `json:"is_verified" bson:"is_verified"`
 }

--- a/internal/users/types/types.go
+++ b/internal/users/types/types.go
@@ -1,0 +1,6 @@
+package types
+
+type DeliverableUser struct {
+	ID primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
+	Name string `json:"name" bson:"name"`
+}

--- a/internal/users/types/types.go
+++ b/internal/users/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import ("go.mongodb.org/mongo-driver/bson/primitive")
+
 type DeliverableUser struct {
 	ID primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	Name string `json:"name" bson:"name"`

--- a/internal/users/types/types.go
+++ b/internal/users/types/types.go
@@ -7,4 +7,5 @@ type DeliverableUser struct {
 	Name string `json:"name" bson:"name"`
 	Email string `json:"email" bson:"email"`
 	//IsVerified bool `json:"is_verified" bson:"is_verified"`
+	//IsDeleted bool `json:"is_deleted" bson:"is_deleted" binding:"required"`
 }

--- a/internal/users/types/types.go
+++ b/internal/users/types/types.go
@@ -5,4 +5,6 @@ import ("go.mongodb.org/mongo-driver/bson/primitive")
 type DeliverableUser struct {
 	ID primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	Name string `json:"name" bson:"name"`
+	Email string `json:"email" bson:"email"`
+	IsVerified bool `json:"is_verified" bson:"is_verified"`
 }


### PR DESCRIPTION
Beginning of the pull request. Issue #4  Work in Progress

### Current State 

Current User Resource Endpoints are:
_POST   /api/v1/users/            --> internal/users.signup 
POST   /api/v1/users/login       --> internal/users.login_ 

----

### Limitations

 We have no way of updating, fetching or deleting User Resource Records

---

### Proposed Changes
Create the following Endpoints

GET   /api/v1/users/            --> internal/users.getUsers
PUT    /api/v1/users/             --> internal/users.update 
 
---

### Justification

For the sake of admins being able to manager User Resource Records, fetching and updating the records are needed. Use the PUT for deleting as well