### PR TITLE
(WIP) API client Resource CRUD ops

### DIFF
--- a/internal/clients/forms.go
+++ b/internal/clients/forms.go
@@ -10,3 +10,8 @@ type updateClientCmd struct {
 	Phone string `json:"phone" binding:"required"`
 	Jobs []types.Job `json:"jobs" binding:"required"`
 }
+
+type createClientCmd struct {
+	Name string `json:"name" binding:"required"`
+	Phone string `json:"phone" binding:"required"`
+}

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -70,15 +70,19 @@ func getClientByID(c *gin.Context) {
 		c.Abort(); return
 	}
 
-	client, err := clientByID(ctx, id)
-	if err != nil {
+	client, err := clientByID(ctx, id); if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
 		c.Abort(); return
 	}
 
-	delivarableClient, err := client.Populate(ctx)
-	if err != nil {
+	if len(client.Jobs) <= 0 {
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": emptyJobsClient(client)})
+		return
+	}
+
+	delivarableClient, err := client.Populate(ctx); if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
 		c.Abort(); return

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -17,24 +17,21 @@ func getClientByPhone(c *gin.Context) {
 	if len(phone) <= 0 {
 		c.JSON(http.StatusBadRequest,
 			gin.H{"success": false, "message": "Provide an id"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	client := ClientByPhone(ctx, phone)
 	if client == nil {
 		c.JSON(http.StatusNotFound,
 			gin.H{"success": false, "message": "No client found"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	delivarableClient, err := client.Populate(ctx)
 	if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	c.JSON(http.StatusOK,
@@ -50,24 +47,21 @@ func getClientByID(c *gin.Context) {
 	if len(id) <= 0 {
 		c.JSON(http.StatusBadRequest,
 			gin.H{"success": false, "message": "Provide an id"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	client, err := clientByID(ctx, id)
 	if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	delivarableClient, err := client.Populate(ctx)
 	if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	c.JSON(http.StatusOK,
@@ -82,24 +76,21 @@ func update(c *gin.Context) {
 	if c.BindJSON(&data) != nil {
 		c.JSON(http.StatusNotAcceptable,
 			gin.H{"success": false, "message": "Provide relevant fields"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	update, err := tryFromUpdateClientCmd(&data)
 	if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	err = update.Put(ctx, false)
 	if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	c.JSON(http.StatusAccepted,
@@ -115,8 +106,7 @@ func fuzzyClientSearch(c *gin.Context) {
 	if len(query) <= 0 {
 		c.JSON(http.StatusBadRequest,
 			gin.H{"success": false, "message": "Provide a query"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	quantity := c.DefaultQuery("quantity", "100")
@@ -124,16 +114,14 @@ func fuzzyClientSearch(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusBadRequest,
 			gin.H{"success": false, "message": "Invalid Quantity"})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	results, serachErr := fuzzySearch(ctx, query, iQuantity)
 	if serachErr != nil {
 		c.JSON(serachErr.Code,
 			gin.H{"success": false, "message": serachErr.Error()})
-		c.Abort()
-		return
+		c.Abort(); return
 	}
 
 	c.JSON(http.StatusOK,

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func createUser(c *gin.Context) {
+func createClient(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()
 

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -204,6 +205,7 @@ func getClients(c *gin.Context) {
 		c.Abort(); return
 	}
 
+	fmt.Println(results)
 	if len(results) > 0 {
 		c.JSON(http.StatusOK,
 			gin.H{"success": true, "payload": results})

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -174,6 +174,14 @@ func getClients(c *gin.Context) {
 		c.Abort(); return
 	}
 
-	c.JSON(http.StatusOK,
-		gin.H{"success": true, "payload": results})
+	if len(results) > 0 {
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": results})
+		return
+	}
+
+	empty := make([]string, 0)
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": empty})
+
 }

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -9,6 +9,26 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func createUser(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c, 5*time.Second)
+	defer cancel()
+
+	var data createClientCmd
+	if c.BindJSON(&data) != nil {
+		c.JSON(http.StatusNotAcceptable,
+			gin.H{"success": false, "message": "Provide relevant fields"});
+		c.Abort(); return
+	}
+	newClient := fromCreateClientCmd(&data)
+	uid, err := newClient.createUniq(ctx); if err != nil {
+		c.JSON(err.Code,
+			gin.H{"success": false, "message": err.Error()});
+		c.Abort(); return
+	}
+	c.JSON(http.StatusCreated,
+		gin.H{"success": true, "payload": uid.String(), "message": "Client Created"})
+}
+
 func getClientByPhone(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()
@@ -183,5 +203,6 @@ func getClients(c *gin.Context) {
 	empty := make([]string, 0)
 		c.JSON(http.StatusOK,
 			gin.H{"success": true, "payload": empty})
-
 }
+
+

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -54,6 +54,12 @@ func getClientByPhone(c *gin.Context) {
 		c.Abort(); return
 	}
 
+	if len(delivarableClient.Jobs) <= 0 {
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": emptyJobsClient(delivarableClient)})
+		return
+	}
+
 	c.JSON(http.StatusOK,
 		gin.H{"success": true, "payload": delivarableClient})
 
@@ -76,16 +82,16 @@ func getClientByID(c *gin.Context) {
 		c.Abort(); return
 	}
 
-	if len(client.Jobs) <= 0 {
-		c.JSON(http.StatusOK,
-			gin.H{"success": true, "payload": emptyJobsClient(client)})
-		return
-	}
-
 	delivarableClient, err := client.Populate(ctx); if err != nil {
 		c.JSON(err.Code,
 			gin.H{"success": false, "message": err.Error()})
 		c.Abort(); return
+	}
+
+	if len(delivarableClient.Jobs) <= 0 {
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": emptyJobsClient(delivarableClient)})
+		return
 	}
 
 	c.JSON(http.StatusOK,

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -205,7 +204,6 @@ func getClients(c *gin.Context) {
 		c.Abort(); return
 	}
 
-	fmt.Println(results)
 	if len(results) > 0 {
 		c.JSON(http.StatusOK,
 			gin.H{"success": true, "payload": results})

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -140,6 +140,7 @@ func fuzzyClientSearch(c *gin.Context) {
 		gin.H{"success": true, "payload": populateClients(ctx, results)})
 }
 
+// TODO: api/v1/clients?all=bool&sorted=bool&source=uint&next=uint
 func getLatestClients(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -44,7 +44,7 @@ func fromCreateClientCmd(data *createClientCmd) *newClient {
 	}
 }
 
-func emptyJobsClient(c *clientModel) *joblessClient {
+func emptyJobsClient(c *types.PopulatedClientModel) *joblessClient {
 	return &joblessClient {
 		ID: c.ID,
 		Name: c.Name,

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -172,7 +172,7 @@ func clientByID(ctx context.Context, id string) (*clientModel, *errors.ResponseE
 	return &foundClient, nil
 }
 
-func latest(ctx context.Context, quantity int64) ([]types.DeliverableClient, *errors.ResponseError) {
+func fetch(ctx context.Context, fetchOpts *BulkFetch) ([]types.DeliverableClient, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 
 	findOptions := options.Find()

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"bytes"
-	"fmt"
 	"context"
 	"internal/clients/types"
 	"internal/common/errors"
@@ -261,7 +260,6 @@ func fetch(ctx context.Context, fetchOpts *BulkFetch) ([]types.UnpopulatedClient
 	if err = cursor.All(ctx, &clients); err != nil {
 		return nil, errors.DatabaseError(err)
 	}
-	fmt.Println(clients)
 	return clients, nil
 }
 

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -25,12 +25,14 @@ type clientModel struct {
 type joblessClient struct {
 	Name  string               `json:"name" bson:"name"`
 	Phone string               `json:"phone" bson:"phone"`
+	Jobs  []primitive.ObjectID `json:"jobs" bson:"jobs"`
 }
 
 func fromCreateClientCmd(data *createClientCmd) *joblessClient {
 	return &joblessClient{
 		Name: data.Name,
 		Phone: data.Phone,
+		Jobs: make([]primitive.ObjectID, 0),
 	}
 }
 

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"bytes"
+	"fmt"
 	"context"
 	"internal/clients/types"
 	"internal/common/errors"
@@ -223,10 +224,10 @@ func fetchAll(ctx context.Context, sort bool) ([]types.UnpopulatedClientModel, *
 	opts := options.Find()
 
 	if sort {
-		//opts.SetSort(bson.D{{"_id", -1}})
+		opts.SetSort(bson.D{{"_id", -1}})
 	}
 
-	cursor, err := coll.Find(ctx, opts)
+	cursor, err := coll.Find(ctx, bson.D{{}}, opts)
 	defer cursor.Close(ctx)
 	var clients []types.UnpopulatedClientModel
 
@@ -253,13 +254,14 @@ func fetch(ctx context.Context, fetchOpts *BulkFetch) ([]types.UnpopulatedClient
 		findOptions.SetSort(bson.D{{"_id", -1}})
 	}
 
-	cursor, err := coll.Find(ctx, findOptions)
+	cursor, err := coll.Find(ctx, bson.D{{}}, findOptions)
 	defer cursor.Close(ctx)
 
 	var clients []types.UnpopulatedClientModel
 	if err = cursor.All(ctx, &clients); err != nil {
 		return nil, errors.DatabaseError(err)
 	}
+	fmt.Println(clients)
 	return clients, nil
 }
 

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -22,17 +22,34 @@ type clientModel struct {
 	Jobs  []primitive.ObjectID `json:"jobs" bson:"jobs"`
 }
 
-type joblessClient struct {
+type newClient struct {
 	Name  string               `json:"name" bson:"name"`
 	Phone string               `json:"phone" bson:"phone"`
 	Jobs  []primitive.ObjectID `json:"jobs" bson:"jobs"`
 }
 
-func fromCreateClientCmd(data *createClientCmd) *joblessClient {
-	return &joblessClient{
+//need this cuz of bug
+type joblessClient struct {
+	ID primitive.ObjectID	`json:"_id"`
+	Name string				`json:"name"`
+	Phone string			`json:"phone"`
+	Jobs []string			`json:"jobs"`
+}
+
+func fromCreateClientCmd(data *createClientCmd) *newClient {
+	return &newClient{
 		Name: data.Name,
 		Phone: data.Phone,
 		Jobs: make([]primitive.ObjectID, 0),
+	}
+}
+
+func emptyJobsClient(c *clientModel) *joblessClient {
+	return &joblessClient {
+		ID: c.ID,
+		Name: c.Name,
+		Phone: c.Phone,
+		Jobs: make([]string, 0),
 	}
 }
 
@@ -101,7 +118,7 @@ func (self *clientModel) create(ctx context.Context) (UID.ID, *errors.ResponseEr
 	return UID.TryFromInterface(res.InsertedID)
 }
 
-func (self *joblessClient) createUniq(ctx context.Context) (UID.ID, *errors.ResponseError) {
+func (self *newClient) createUniq(ctx context.Context) (UID.ID, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 	exists := ClientByPhone(ctx, self.Phone)
 	if exists != nil {

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -214,6 +214,5 @@ func fetch(ctx context.Context, fetchOpts *BulkFetch) ([]types.UnpopulatedClient
 	if err = cursor.All(ctx, &clients); err != nil {
 		return nil, errors.DatabaseError(err)
 	}
-
 	return clients, nil
 }

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -176,7 +176,7 @@ func fetch(ctx context.Context, fetchOpts *BulkFetch) ([]types.DeliverableClient
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 
 	findOptions := options.Find()
-	findOptions.SetLimit(quantity)
+	//findOptions.SetLimit(quantity)
 	findOptions.SetSort(bson.D{{"_id", -1}})
 	//filter := bson.D{{"jobs", false}}
 

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -34,7 +34,6 @@ func fromCreateClientCmd(data *createClientCmd) *joblessClient {
 	}
 }
 
-
 func tryFromUpdateClientCmd(data *updateClientCmd) (*clientModel, *errors.ResponseError) {
 	clientOID, err := primitive.ObjectIDFromHex(data.ID)
 	if err != nil {
@@ -102,6 +101,11 @@ func (self *clientModel) create(ctx context.Context) (UID.ID, *errors.ResponseEr
 
 func (self *joblessClient) createUniq(ctx context.Context) (UID.ID, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
+	exists := ClientByPhone(ctx, self.Phone)
+	if exists != nil {
+		return nil, errors.DoesNotExist()
+	}
+
 	res, err := coll.InsertOne(ctx, self)
 	if err != nil {
 		return nil, errors.DatabaseError(err)

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -223,7 +223,7 @@ func fetchAll(ctx context.Context, sort bool) ([]types.UnpopulatedClientModel, *
 	opts := options.Find()
 
 	if sort {
-		opts.SetSort(bson.D{{"_id", -1}})
+		//opts.SetSort(bson.D{{"_id", -1}})
 	}
 
 	cursor, err := coll.Find(ctx, opts)

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -2,15 +2,15 @@ package clients
 
 type BulkFetch struct {
 	All bool
-	Sorted bool
-	Source uint
-	Next uint
+	Sort bool
+	Source uint64
+	Next uint64
 }
 
 func BulkFetchOptions() *BulkFetch {
 	return &BulkFetch{
 		All: false,
-		Sorted: false,
+		Sort: false,
 		Source: 0,
 		Next: 10,
 	}
@@ -22,16 +22,17 @@ func (opts *BulkFetch) FetchAll() *BulkFetch {
 }
 
 func (opts *BulkFetch) FetchSorted() *BulkFetch {
-	opts.Sorted = true
+	opts.Sort = true
 	return opts
 }
 
-func (opts *BulkFetch) SetSource(source uint) *BulkFetch {
+func (opts *BulkFetch) SetSource(source uint64) *BulkFetch {
 	opts.Source = source
 	return opts
 }
 
-func (opts *BulkFetch) SetNext(next uint) *BulkFetch {
+func (opts *BulkFetch) SetNext(next uint64) *BulkFetch {
 	opts.Next = next
 	return opts
 }
+

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -1,0 +1,37 @@
+package clients
+
+type BulkFetch struct {
+	All bool
+	Sorted bool
+	Source uint
+	Next uint
+}
+
+func BulkFetchOptions() *BulkFetch {
+	return &BulkFetch{
+		All: false,
+		Sorted: false,
+		Source: 0,
+		Next: 10,
+	}
+}
+
+func (opts *BulkFetch) FetchAll() *BulkFetch {
+	opts.All = true
+	return opts
+}
+
+func (opts *BulkFetch) FetchSorted() *BulkFetch {
+	opts.Sorted = true
+	return opts
+}
+
+func (opts *BulkFetch) SetSource(source uint) *BulkFetch {
+	opts.Source = source
+	return opts
+}
+
+func (opts *BulkFetch) SetNext(next uint) *BulkFetch {
+	opts.Next = next
+	return opts
+}

--- a/internal/clients/routers.go
+++ b/internal/clients/routers.go
@@ -8,6 +8,6 @@ func ClientRoutesRegister(router *gin.RouterGroup) {
 	router.GET("/client/:id", getClientByID)
 	router.GET("/phone/:phone", getClientByPhone)
 	router.PUT("/", update)
-	router.GET("/", getLatestClients)
+	router.GET("/", getClients)
 	router.GET("/search/:query", fuzzyClientSearch)
 }

--- a/internal/clients/routers.go
+++ b/internal/clients/routers.go
@@ -10,4 +10,5 @@ func ClientRoutesRegister(router *gin.RouterGroup) {
 	router.PUT("/", update)
 	router.GET("/", getClients)
 	router.GET("/search/:query", fuzzyClientSearch)
+	router.POST("/", createClient)
 }

--- a/internal/clients/types/types.go
+++ b/internal/clients/types/types.go
@@ -31,4 +31,5 @@ type DeliverableClient struct {
 	ID primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	Name string `json:"name" bson:"name"`
 	Phone string `json:"phone" bson:"phone"`
+	Jobs []jobTypes.Job `json:"jobs" bosn:"jobs"`
 }

--- a/internal/clients/types/types.go
+++ b/internal/clients/types/types.go
@@ -14,6 +14,13 @@ type PopulatedClientModel struct {
 	Jobs []jobTypes.Job `json:"jobs"`
 }
 
+type UnpopulatedClientModel struct {
+	ID primitive.ObjectID `json:"_id"`
+	Name string `json:"name"`
+	Phone string `json:"phone"`
+	Jobs []primitive.ObjectID `json:"jobs"`
+}
+
 type Client interface {
 	AttatchJobID(primitive.ObjectID)
 	Put(ctx context.Context, upsert bool) *errors.ResponseError

--- a/internal/clients/types/types.go
+++ b/internal/clients/types/types.go
@@ -15,10 +15,10 @@ type PopulatedClientModel struct {
 }
 
 type UnpopulatedClientModel struct {
-	ID primitive.ObjectID `json:"_id"`
-	Name string `json:"name"`
-	Phone string `json:"phone"`
-	Jobs []primitive.ObjectID `json:"jobs"`
+	ID primitive.ObjectID `json:"_id" bson:"_id"`
+	Name string `json:"name" bson:"name"`
+	Phone string `json:"phone" bson:"phone"`
+	Jobs []primitive.ObjectID `json:"jobs" bson"jobs"`
 }
 
 type Client interface {


### PR DESCRIPTION
In reference to Issue #2 

### Current State
Current Client Resource endpoints are:

_GET    /api/v1/clients/client/:id --> internal/clients.getClientByID 
GET    /api/v1/clients/phone/:phone --> internal/clients.getClientByPhone 
PUT    /api/v1/clients/  --> internal/clients.update
GET    /api/v1/clients/search/:query --> internal/clients.fuzzyClientSearch 
GET    /api/v1/clients/          --> internal/clients.getLatestClients_ 

-------

### Limitation

1. _GET    /api/v1/clients/   --> internal/clients.getLatestClients_ 
Currently hard-coded to retrieve 100 clients.
2. There is no POST endpoint

-------

### Proposed Changes

1. Change this API endpoint to be:
_GET    /api/v1/clients/   --> internal/clients.getClients_ 
Use a Query string in the form of
  _/api/v1/clients?all=**bool**&sort=**bool**&source=**uint**&next=**uint**_

- **all** is a boolean, if **TRUE**, return all client resource database records. If **FALSE**, a range of records must be correctly specified.
-  **sort** is a boolean, if **TRUE**, sort them by most recently used. If **FALSE**, return the order found in the database.
- **source** is an unsigned integer. This is the starting position of the sorted or unsorted database records
- **next** is an unsigned integer. This is the number of database records to retrieve starting from the source parameter from above.

2.Create the following endpoint*
 _POST   /api/v1/clients/ --> internal/clients.create_  
This endpoint would allow us to create a Client record by itself. However, the 
_POST   /api/v1/jobs/ --> internal/jobs.submitJob_ endpoint will create a Job and the corresponding client record if one doesn't exist.

-------

### Justification

- These enhancements will allow the endpoint to be used for retrieving client resource records from specific ranges (or all of them) in a sorted or unsorted ordering. The range allows for server-side pagination. 
- The POST endpoint will allow the creation of a client record without any corresponding Jobs. Potentially useful for collecting client record information by itself.