### PR TITLE
API Client Resource Fuzzy-ish search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/kisielk/errcheck v1.2.0 // indirect
+	github.com/mxschmitt/golang-combinations v1.1.0 // indirect
 	go.mongodb.org/mongo-driver v1.3.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	internal/clients v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mxschmitt/golang-combinations v1.1.0 h1:WlIZCnDm+Xlb2pRPf+R/qPKlGOU1w8lpN69/uy5z+Zg=
+github.com/mxschmitt/golang-combinations v1.1.0/go.mod h1:RbMhWvfCelHR6WROvT2bVfxJvZHoEvBj71SKe+H0MYU=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -158,15 +158,6 @@ func fuzzyClientSearch(c *gin.Context) {
 	}
 	options.Next = iNext
 
-	sort := c.DefaultQuery("sort", "false")
-	bSort, err := strconv.ParseBool(sort); if err != nil {
-		c.JSON(http.StatusBadRequest,
-			gin.H{"success": false, "message": "Invalid sort Param"})
-		c.Abort(); return
-	}
-	options.Sort = bSort
-
-
 	results, serachErr := fuzzySearch(ctx, options)
 	if serachErr != nil {
 		c.JSON(serachErr.Code,

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -128,6 +128,7 @@ func update(c *gin.Context) {
 
 }
 
+//TODO: fuzzy search
 func fuzzyClientSearch(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -137,9 +137,6 @@ func fuzzyClientSearch(c *gin.Context) {
 	options := FuzzySearchOptions()
 
 	term := c.DefaultQuery("term", string(""))
-		c.JSON(http.StatusBadRequest,
-			gin.H{"success": false, "message": "Invalid term Param"})
-		c.Abort(); return
 	options.Term = term
 
 	source := c.DefaultQuery("source", "0")

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -127,8 +127,7 @@ func update(c *gin.Context) {
 		gin.H{"success": true, "message": "Job Updated"})
 
 }
-
-//TODO: fuzzy search
+/*
 //api/v1/clients/search?term=string&source=uint&next=uint&sort=bool
 func fuzzyClientSearch(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
@@ -172,8 +171,8 @@ func fuzzyClientSearch(c *gin.Context) {
 	c.JSON(http.StatusOK,
 		gin.H{"success": true, "payload": results})
 }
-
-// TODO: api/v1/clients?all=bool&sort=bool&source=uint&next=uint
+*/
+// api/v1/clients?all=bool&sort=bool&source=uint&next=uint
 func getClients(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -129,26 +129,45 @@ func update(c *gin.Context) {
 }
 
 //TODO: fuzzy search
+//api/v1/clients/search?term=string&source=uint&next=uint&sort=bool
 func fuzzyClientSearch(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c, 5*time.Second)
 	defer cancel()
 
-	query := c.Param("query") //returns empty string if not there
-	if len(query) <= 0 {
+	options := FuzzySearchOptions()
+
+	term := c.DefaultQuery("term", string(""))
 		c.JSON(http.StatusBadRequest,
-			gin.H{"success": false, "message": "Provide a query"})
+			gin.H{"success": false, "message": "Invalid term Param"})
+		c.Abort(); return
+	options.Term = term
+
+	source := c.DefaultQuery("source", "0")
+	iSource, err := strconv.ParseUint(source, 10, 64); if err != nil {
+		c.JSON(http.StatusBadRequest,
+			gin.H{"success": false, "message": "Invalid Source Param"})
 		c.Abort(); return
 	}
+	options.Source = iSource
 
-	quantity := c.DefaultQuery("quantity", "100")
-	iQuantity, err := strconv.Atoi(quantity)
-	if err != nil {
+	next := c.DefaultQuery("next", "10")
+	iNext, err := strconv.ParseUint(next, 10, 64); if err != nil {
 		c.JSON(http.StatusBadRequest,
-			gin.H{"success": false, "message": "Invalid Quantity"})
+			gin.H{"success": false, "message": "Invalid Next Param"})
 		c.Abort(); return
 	}
+	options.Next = iNext
 
-	results, serachErr := fuzzySearch(ctx, query, iQuantity)
+	sort := c.DefaultQuery("sort", "false")
+	bSort, err := strconv.ParseBool(sort); if err != nil {
+		c.JSON(http.StatusBadRequest,
+			gin.H{"success": false, "message": "Invalid sort Param"})
+		c.Abort(); return
+	}
+	options.Sort = bSort
+
+
+	results, serachErr := fuzzySearch(ctx, options)
 	if serachErr != nil {
 		c.JSON(serachErr.Code,
 			gin.H{"success": false, "message": serachErr.Error()})

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -175,7 +175,7 @@ func fuzzyClientSearch(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK,
-		gin.H{"success": true, "payload": populateClients(ctx, results)})
+		gin.H{"success": true, "payload": results})
 }
 
 // TODO: api/v1/clients?all=bool&sort=bool&source=uint&next=uint

--- a/internal/clients/handlers.go
+++ b/internal/clients/handlers.go
@@ -162,6 +162,13 @@ func fuzzyClientSearch(c *gin.Context) {
 		c.Abort(); return
 	}
 
+	if len(results) <= 0 {
+		empty := make([]string, 0)
+		c.JSON(http.StatusOK,
+			gin.H{"success": true, "payload": empty})
+		c.Abort(); return
+	}
+
 	c.JSON(http.StatusOK,
 		gin.H{"success": true, "payload": results})
 }

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -209,12 +209,30 @@ func powersetRegex(term string) string {
 	powerset = powerset[1:]
 
 	regex := "^" + term + "$" + "|"
-	for i:=0; i<len(powerset); i++ {
+	regex = regex + "("
+	for i:=len(powerset)-1; i>=0; i-- {
+		regexTerm := strings.Join(powerset[i], "")
+		regexTerm = "^" + regexTerm + "$"
+		regex = regex + "(" + regexTerm + ")" //+ "|"
+	}
+	regex = regex + "){1}" //+ "|"
+
+	/*for i:=len(powerset)-1; i>=0; i-- {
 		regexTerm := strings.Join(powerset[i], "")
 		regexTerm = "^" + regexTerm + "$"
 		regex = regex + regexTerm + "|"
+	}*/
+
+	/*termArr = termArr[1:]
+	powerset = combinations.All(termArr)
+	regex = regex + "("
+	for i:=0; i<len(powerset); i++ {
+		regexTerm := strings.Join(powerset[i], "")
+		regex = regex + "(" + regexTerm + ")" + "|"
 	}
-	return regex + term
+	regex = strings.TrimSuffix(regex, "|")
+	return regex + "){1}"*/
+	return regex
 }
 
 func populateClients(ctx context.Context, clients []clientModel) []types.PopulatedClientModel {

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -174,10 +174,11 @@ func (self *clientModel) Populate(ctx context.Context) (*types.PopulatedClientMo
 }
 
 //TODO: fuzzy search for client
-func fuzzySearch(ctx context.Context, query string, quantity int) ([]clientModel, *errors.ResponseError) {
+func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]clientModel, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 
-	filter := bson.D{{"name", primitive.Regex{Pattern: query, Options: "i"}}}
+	//filter := bson.D{{"name", primitive.Regex{Pattern: query, Options: "i"}}}
+	filter := bson.D{{}}
 
 	cursor, err := coll.Find(ctx, filter)
 	defer cursor.Close(ctx)

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -174,19 +174,22 @@ func (self *clientModel) Populate(ctx context.Context) (*types.PopulatedClientMo
 }
 
 //TODO: fuzzy search for client
+//https://github.com/mongodb/mongo-go-driver/blob/51421e413403fe3c9b0097147841f752421133e4/examples/documentation_examples/examples.go#L293
 func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]types.UnpopulatedClientModel, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 
 	//filter := bson.D{{"name", primitive.Regex{Pattern: query, Options: "i"}}}
-	findOptions := options.
-	Find().
-	SetSkip(int64(opts.Source)).
-	SetLimit(int64(opts.Next))
+//	findOptions := options.
+//	Find()//.
+	//SetSkip(int64(opts.Source)).
+	//SetLimit(int64(opts.Next))
 
-
-
-	filter := bson.D{{"name", primitive.Regex{Pattern: opts.Term, Options: "gi"}}}
-	cursor, err := coll.Find(ctx, filter, findOptions)
+	//pattern := "/asdf/"
+	//filter := bson.D{{"name", bson.D{{"$regex", primitive.Regex{Pattern: "/"+opts.Term+"/"}}}}}
+	//filter := bson.M{"name":bson.M{"$regex":pattern}}
+	//filter := bson.D{{"name", primitive.Regex{Pattern:"^asdf$", Options:""}}}
+	filter := bson.D{{"name", "asdf"}}
+	cursor, err := coll.Find(ctx, filter)//, findOptions)
 	defer cursor.Close(ctx)
 
 	var clients []types.UnpopulatedClientModel

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -3,8 +3,8 @@ package clients
 import (
 	"bytes"
 	"context"
-	"strings"
-	"fmt"
+	//"strings"
+	//"fmt"
 	"internal/clients/types"
 	"internal/common/errors"
 	"internal/db"
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	combinations "github.com/mxschmitt/golang-combinations"
+	//combinations "github.com/mxschmitt/golang-combinations"
 )
 
 type clientModel struct {
@@ -176,7 +176,7 @@ func (self *clientModel) Populate(ctx context.Context) (*types.PopulatedClientMo
 	}, nil
 }
 
-//TODO: fuzzy search for client
+/*
 //https://github.com/mongodb/mongo-go-driver/blob/51421e413403fe3c9b0097147841f752421133e4/examples/documentation_examples/examples.go#L293
 func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]types.UnpopulatedClientModel, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
@@ -217,24 +217,9 @@ func powersetRegex(term string) string {
 	}
 	regex = regex + "){1}" //+ "|"
 
-	/*for i:=len(powerset)-1; i>=0; i-- {
-		regexTerm := strings.Join(powerset[i], "")
-		regexTerm = "^" + regexTerm + "$"
-		regex = regex + regexTerm + "|"
-	}*/
-
-	/*termArr = termArr[1:]
-	powerset = combinations.All(termArr)
-	regex = regex + "("
-	for i:=0; i<len(powerset); i++ {
-		regexTerm := strings.Join(powerset[i], "")
-		regex = regex + "(" + regexTerm + ")" + "|"
-	}
-	regex = strings.TrimSuffix(regex, "|")
-	return regex + "){1}"*/
 	return regex
 }
-
+*/
 func populateClients(ctx context.Context, clients []clientModel) []types.PopulatedClientModel {
 
 	populatedClients := make([]types.PopulatedClientModel, 0, len(clients))

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -183,11 +183,10 @@ func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]types.UnpopulatedCli
 	SetSkip(int64(opts.Source)).
 	SetLimit(int64(opts.Next))
 
-	if opts.Sort {
-		findOptions.SetSort(bson.D{{"_id", -1}})
-	}
 
-	cursor, err := coll.Find(ctx, bson.D{{}}, findOptions)
+
+	filter := bson.D{{"name", primitive.Regex{Pattern: opts.Term, Options: "gi"}}}
+	cursor, err := coll.Find(ctx, filter, findOptions)
 	defer cursor.Close(ctx)
 
 	var clients []types.UnpopulatedClientModel

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -201,7 +201,7 @@ func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]types.UnpopulatedCli
 
 func powersetRegex(term string) string {
 	var termArr = make([]string, 0, len(term))
-	termArr = append(termArr, ".")
+	termArr = append(termArr, "..")
 	for i:=0; i<len(term); i++ {
 		termArr = append(termArr, string(term[i]))
 	}

--- a/internal/clients/models.go
+++ b/internal/clients/models.go
@@ -178,18 +178,13 @@ func (self *clientModel) Populate(ctx context.Context) (*types.PopulatedClientMo
 func fuzzySearch(ctx context.Context, opts *FuzzySearch) ([]types.UnpopulatedClientModel, *errors.ResponseError) {
 	coll := db.Connection().Use(db.DefaultDatabase, "clients")
 
-	//filter := bson.D{{"name", primitive.Regex{Pattern: query, Options: "i"}}}
-//	findOptions := options.
-//	Find()//.
-	//SetSkip(int64(opts.Source)).
-	//SetLimit(int64(opts.Next))
+	findOptions := options.
+	Find().
+	SetSkip(int64(opts.Source)).
+	SetLimit(int64(opts.Next))
 
-	//pattern := "/asdf/"
-	//filter := bson.D{{"name", bson.D{{"$regex", primitive.Regex{Pattern: "/"+opts.Term+"/"}}}}}
-	//filter := bson.M{"name":bson.M{"$regex":pattern}}
-	//filter := bson.D{{"name", primitive.Regex{Pattern:"^asdf$", Options:""}}}
-	filter := bson.D{{"name", "asdf"}}
-	cursor, err := coll.Find(ctx, filter)//, findOptions)
+	filter := bson.D{{"name", primitive.Regex{Pattern: opts.Term, Options:""}}}
+	cursor, err := coll.Find(ctx, filter, findOptions)
 	defer cursor.Close(ctx)
 
 	var clients []types.UnpopulatedClientModel

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -11,7 +11,6 @@ type FuzzySearch struct {
 	Term string
 	Source uint64
 	Next uint64
-	Sort bool
 }
 
 func FuzzySearchOptions() *FuzzySearch {
@@ -19,7 +18,6 @@ func FuzzySearchOptions() *FuzzySearch {
 		Term: "",
 		Source: 0,
 		Next: 10,
-		Sort: false,
 	}
 }
 

--- a/internal/clients/options.go
+++ b/internal/clients/options.go
@@ -7,6 +7,22 @@ type BulkFetch struct {
 	Next uint64
 }
 
+type FuzzySearch struct {
+	Term string
+	Source uint64
+	Next uint64
+	Sort bool
+}
+
+func FuzzySearchOptions() *FuzzySearch {
+	return &FuzzySearch{
+		Term: "",
+		Source: 0,
+		Next: 10,
+		Sort: false,
+	}
+}
+
 func BulkFetchOptions() *BulkFetch {
 	return &BulkFetch{
 		All: false,

--- a/internal/clients/routers.go
+++ b/internal/clients/routers.go
@@ -9,6 +9,6 @@ func ClientRoutesRegister(router *gin.RouterGroup) {
 	router.GET("/phone/:phone", getClientByPhone)
 	router.PUT("/", update)
 	router.GET("/", getClients)
-	router.GET("/search/:query", fuzzyClientSearch)
+	router.GET("/search/", fuzzyClientSearch)
 	router.POST("/", createClient)
 }

--- a/internal/clients/routers.go
+++ b/internal/clients/routers.go
@@ -9,6 +9,6 @@ func ClientRoutesRegister(router *gin.RouterGroup) {
 	router.GET("/phone/:phone", getClientByPhone)
 	router.PUT("/", update)
 	router.GET("/", getClients)
-	router.GET("/search/", fuzzyClientSearch)
+	//router.GET("/search/", fuzzyClientSearch)
 	router.POST("/", createClient)
 }


### PR DESCRIPTION
In reference to Issue #3 

---

### Current State

In reference to the _GET /api/v1/clients/search/:query --> internal/clients.fuzzyClientSearch_ endpoint
Executes but returns an empty array

-------

### Limitation

Usage of the current Regular Expression is essentially equivalent to a partial string search and there is no input sanitation which could lead to security risk. 

-------

### Proposed Changes

1. - Option 1: Relax the Regular Expression to allow for matching of characters to their relative order of appearance. For example, given an input string _abfg_, as long as at least a subset of those characters appear in the string being matched to in sequence, then include it as a match. So _abgf_ and the database record _ab_ should match. This may need a ranking mechanism to sort by most relevantly matched strings. With a ranking mechanism, _abgf_ would loosely match _ab_ whereas an input string like _a_ would be a stronger match since the number of characters matched are less than the number of characters that weren't matched. Similarly _abc_ is a stronger match than _abgf_. We can take these matches and rank the more closely related matches as more relevant so that they appear higher in the search list.
    - Option 2: Use an external fuzzy search module and keep it in sync with the database collection.
2. Sanitize the inputs

-------

### Justification

I suspect that the Regular Expression matching is too strict and is trying to exactly match on the partial string instead of partially matching the given string to the client resource records. This could be what is causing the records to not match.  For _Option 2_, the problem transforms into a synchronization problem instead of a fuzzy search problem.